### PR TITLE
Fix missing conditional compilation for global_registry feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use std::{rc::Rc, sync::Arc};
 
 #[cfg(feature = "global_registry")]
 mod global;
-
+#[cfg(feature = "global_registry")]
 pub use global::*;
 
 // Re-exports for `register!()` macro


### PR DESCRIPTION
Fix compilation failure when using `crosstrait = { path = "../crosstrait", default-features = false, features = [] }` in main.